### PR TITLE
Add StandWithUkraine banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/banner2-direct.svg)](https://stand-with-ukraine.pp.ua)
 **NearDrop** is a partial implementation of [Google's Nearby Share](https://blog.google/products/android/nearby-share/) for macOS.
+
+
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
+[![Russian Warship Go Fuck Yourself](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/RussianWarship.svg)](https://stand-with-ukraine.pp.ua)
+
 
 [Protocol documentation](/PROTOCOL.md) is available separately.
 


### PR DESCRIPTION
This commit adds a banner to the README.md file to show support for Ukraine in its struggle against Russian aggression. The banner links to a website that provides information and resources on how to stand with Ukraine and help its people defend their sovereignty and democracy. The banner is a simple and effective way to raise awareness and solidarity among the GitHub community and beyond. I hope you will accept this pull request and join me in standing with Ukraine. Thank you.