### PR TITLE
Added sleep prevention during file transfer

### DIFF
--- a/NearDrop.xcodeproj/project.pbxproj
+++ b/NearDrop.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		18637D0E2AC2A25300AF8072 /* NearDrop-InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 18637D0C2AC2A25300AF8072 /* NearDrop-InfoPlist.strings */; };
 		18637D112AC2A25300AF8072 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 18637D0F2AC2A25300AF8072 /* InfoPlist.strings */; };
+		2550A5042ADC73A6004C64D2 /* SleepManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2550A5032ADC73A6004C64D2 /* SleepManager.swift */; };
 		691F53BB2ABB70840089FD92 /* DeviceListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 691F53B92ABB70840089FD92 /* DeviceListCell.swift */; };
 		691F53BC2ABB70840089FD92 /* DeviceListCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 691F53BA2ABB70840089FD92 /* DeviceListCell.xib */; };
 		691F53BE2ABF03820089FD92 /* OutboundNearbyConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 691F53BD2ABF03820089FD92 /* OutboundNearbyConnection.swift */; };
@@ -125,6 +126,7 @@
 		1884486C2AC294C3003EC2A3 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		1884486D2AC294C3003EC2A3 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
 		1884486E2AC294C3003EC2A3 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		2550A5032ADC73A6004C64D2 /* SleepManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepManager.swift; sourceTree = "<group>"; };
 		2C284C432AB9FFA200F8D624 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "pt-BR"; path = "pt-BR.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
 		2C284C442AB9FFA200F8D624 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		3226184D2A51E10600B06FD1 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = de; path = de.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -308,6 +310,7 @@
 				691F53BD2ABF03820089FD92 /* OutboundNearbyConnection.swift */,
 				698DFAE529E2F91A0064F247 /* NearbyConnection.swift */,
 				69DA9A2029E0CC4E00A442DA /* Data+Extensions.swift */,
+				2550A5032ADC73A6004C64D2 /* SleepManager.swift */,
 			);
 			path = NearbyShare;
 			sourceTree = "<group>";
@@ -499,6 +502,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				69DCF48D2AB70E8C00CBE2CC /* offline_wire_formats.pb.swift in Sources */,
+				2550A5042ADC73A6004C64D2 /* SleepManager.swift in Sources */,
 				69DCF48F2AB70E8C00CBE2CC /* securemessage.pb.swift in Sources */,
 				69DCF4912AB70E9700CBE2CC /* NearbyConnection.swift in Sources */,
 				69DCF4922AB70E9700CBE2CC /* NearbyConnectionManager.swift in Sources */,

--- a/NearbyShare/NearbyConnection.swift
+++ b/NearbyShare/NearbyConnection.swift
@@ -55,10 +55,12 @@ class NearbyConnection{
 			if case .ready = state {
 				self.connectionReady()
 				self.receiveFrameAsync()
+				SleepManager.shared.disableSleep()
 			} else if case .failed(let err) = state {
 				self.lastError=err
 				print("Error opening socket: \(err)")
 				self.handleConnectionClosure()
+				SleepManager.shared.enableSleep()
 			}
 		}
 		//connection.start(queue: .global(qos: .utility))

--- a/NearbyShare/NearbyConnectionManager.swift
+++ b/NearbyShare/NearbyConnectionManager.swift
@@ -385,5 +385,9 @@ public class NearbyConnectionManager : NSObject, NetServiceDelegate, InboundNear
 		}
 		outgoingTransfers.removeValue(forKey: connection.id)
 	}
+	
+	public func getActiveConnectionsCount() -> Int {
+		return activeConnections.count
+	}
 }
 

--- a/NearbyShare/SleepManager.swift
+++ b/NearbyShare/SleepManager.swift
@@ -1,0 +1,39 @@
+//
+//  SleepManager.swift
+//  NearbyShare
+//
+//  Created by Mika on 15.10.23.
+//
+
+import Foundation
+import IOKit
+import IOKit.pwr_mgt
+
+class SleepManager{
+	public static let shared=SleepManager()
+	private var assertionID: IOPMAssertionID=0
+
+	public func disableSleep(){
+		if(assertionID != 0){
+			return
+		}
+
+		IOPMAssertionCreateWithName(
+			kIOPMAssertionTypePreventUserIdleSystemSleep as CFString,
+			IOPMAssertionLevel(kIOPMAssertionLevelOn),
+			"Data transfer over NearDrop" as CFString,
+			&assertionID
+		)
+	}
+
+	public func enableSleep(){
+		if(assertionID == 0 || NearbyConnectionManager.shared.getActiveConnectionsCount() != 0){
+			return
+		}
+
+		IOPMAssertionRelease(assertionID)
+		assertionID = 0
+	}
+
+	private init(){}
+}


### PR DESCRIPTION
When I was transferring a large file, my MacBook went into sleep mode and this caused the transfer to stop. The screen can still dim or turn off. But MacOS itself does not go into sleep mode.