### PR TITLE
Show how to add NearDrop extension when sharing from Mac to Mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Make sure both devices are on the same Wi-Fi network. Local network communicatio
 
 #### How do I send files?
 
-Right-click a file in Finder, select Share, then select NearDrop.
+Right-click a file in Finder, select Share, then select NearDrop. Be sure to [add the extension](https://github.com/grishka/NearDrop/assets/25108287/bf487c1f-28f4-41a2-99c9-c104ec5d0837).
 
 #### How do I send links?
 


### PR DESCRIPTION
I noticed that NearDrop, at least for me, didn't show up in the "Share" menu. This commit adds a video that shows how to add NearDrop as an extension so that it does show up in the "Share" menu.

https://github.com/grishka/NearDrop/assets/25108287/bf487c1f-28f4-41a2-99c9-c104ec5d0837