### PR TITLE
Fix Gatekeeper warning for Homebrew installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you want the app to start on boot, [follow these steps to add NearDrop as a l
 #### Installation with Homebrew
 
 ```
-brew install grishka/grishka/neardrop
+brew install --no-quarantine grishka/grishka/neardrop
 ```
 
 ## Contributing


### PR DESCRIPTION
See:
- https://support.apple.com/en-us/102445
- https://docs.brew.sh/FAQ#why-cant-i-open-a-mac-app-from-an-unidentified-developer