### PR TITLE
fix macos 15 discovery issue

### DIFF
--- a/NearDrop.xcodeproj/project.pbxproj
+++ b/NearDrop.xcodeproj/project.pbxproj
@@ -523,6 +523,9 @@
 				INFOPLIST_FILE = ShareExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = NearDrop;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "NearDrop needs local network access to discover nearby devices.";
+				INFOPLIST_KEY_NSBonjourServices = "_FC9F5ED42C8A._tcp";
+
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -549,6 +552,9 @@
 				INFOPLIST_FILE = ShareExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = NearDrop;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "NearDrop needs local network access to discover nearby devices.";
+				INFOPLIST_KEY_NSBonjourServices = "_FC9F5ED42C8A._tcp";
+
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -701,6 +707,9 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "NearDrop needs local network access to discover nearby devices.";
+				INFOPLIST_KEY_NSBonjourServices = "_FC9F5ED42C8A._tcp";
+
 				INFOPLIST_KEY_NSMainNibFile = MainMenu;
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -737,6 +746,9 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "NearDrop needs local network access to discover nearby devices.";
+				INFOPLIST_KEY_NSBonjourServices = "_FC9F5ED42C8A._tcp";
+
 				INFOPLIST_KEY_NSMainNibFile = MainMenu;
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/NearbyShare/NearbyConnectionManager.swift
+++ b/NearbyShare/NearbyConnectionManager.swift
@@ -206,7 +206,9 @@ public class NearbyConnectionManager : NSObject, NetServiceDelegate, InboundNear
 	public static let shared=NearbyConnectionManager()
 	
 	override init() {
-		tcpListener=try! NWListener(using: NWParameters(tls: .none))
+		let params = NWParameters(tls: .none)
+		params.includePeerToPeer = true
+		tcpListener=try! NWListener(using: params)
 		super.init()
 	}
 	
@@ -251,6 +253,7 @@ public class NearbyConnectionManager : NSObject, NetServiceDelegate, InboundNear
 		
 		let port:Int32=Int32(tcpListener.port!.rawValue)
 		mdnsService=NetService(domain: "", type: "_FC9F5ED42C8A._tcp.", name: name, port: port)
+		mdnsService?.includesPeerToPeer=true
 		mdnsService?.delegate=self
 		mdnsService?.setTXTRecord(NetService.data(fromTXTRecord: [
 			"n": endpointInfo.serialize().urlSafeBase64EncodedString().data(using: .utf8)!
@@ -278,7 +281,9 @@ public class NearbyConnectionManager : NSObject, NetServiceDelegate, InboundNear
 		if discoveryRefCount==0{
 			foundServices.removeAll()
 			if browser==nil{
-				browser=NWBrowser(for: .bonjourWithTXTRecord(type: "_FC9F5ED42C8A._tcp.", domain: nil), using: .tcp)
+				let params = NWParameters.tcp
+				params.includePeerToPeer = true
+				browser=NWBrowser(for: .bonjourWithTXTRecord(type: "_FC9F5ED42C8A._tcp.", domain: nil), using: params)
 				browser?.browseResultsChangedHandler={newResults, changes in
 					for change in changes{
 						switch change{

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,78 @@
+diff --git a/NearDrop.xcodeproj/project.pbxproj b/NearDrop.xcodeproj/project.pbxproj
+index 9490124..4212ab3 100644
+--- a/NearDrop.xcodeproj/project.pbxproj
++++ b/NearDrop.xcodeproj/project.pbxproj
+@@ -523,6 +523,9 @@
+ 				INFOPLIST_FILE = ShareExtension/Info.plist;
+ 				INFOPLIST_KEY_CFBundleDisplayName = NearDrop;
+ 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
++				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "NearDrop needs local network access to discover nearby devices.";
++				INFOPLIST_KEY_NSBonjourServices = "_FC9F5ED42C8A._tcp";
++
+ 				LD_RUNPATH_SEARCH_PATHS = (
+ 					"$(inherited)",
+ 					"@executable_path/../Frameworks",
+@@ -549,6 +552,9 @@
+ 				INFOPLIST_FILE = ShareExtension/Info.plist;
+ 				INFOPLIST_KEY_CFBundleDisplayName = NearDrop;
+ 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
++				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "NearDrop needs local network access to discover nearby devices.";
++				INFOPLIST_KEY_NSBonjourServices = "_FC9F5ED42C8A._tcp";
++
+ 				LD_RUNPATH_SEARCH_PATHS = (
+ 					"$(inherited)",
+ 					"@executable_path/../Frameworks",
+@@ -701,6 +707,9 @@
+ 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
+ 				INFOPLIST_KEY_LSUIElement = YES;
+ 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
++				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "NearDrop needs local network access to discover nearby devices.";
++				INFOPLIST_KEY_NSBonjourServices = "_FC9F5ED42C8A._tcp";
++
+ 				INFOPLIST_KEY_NSMainNibFile = MainMenu;
+ 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
+ 				LD_RUNPATH_SEARCH_PATHS = (
+@@ -737,6 +746,9 @@
+ 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
+ 				INFOPLIST_KEY_LSUIElement = YES;
+ 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
++				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "NearDrop needs local network access to discover nearby devices.";
++				INFOPLIST_KEY_NSBonjourServices = "_FC9F5ED42C8A._tcp";
++
+ 				INFOPLIST_KEY_NSMainNibFile = MainMenu;
+ 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
+ 				LD_RUNPATH_SEARCH_PATHS = (
+diff --git a/NearbyShare/NearbyConnectionManager.swift b/NearbyShare/NearbyConnectionManager.swift
+index 9f4658f..72d562b 100644
+--- a/NearbyShare/NearbyConnectionManager.swift
++++ b/NearbyShare/NearbyConnectionManager.swift
+@@ -206,7 +206,9 @@ public class NearbyConnectionManager : NSObject, NetServiceDelegate, InboundNear
+ 	public static let shared=NearbyConnectionManager()
+ 	
+ 	override init() {
+-		tcpListener=try! NWListener(using: NWParameters(tls: .none))
++		let params = NWParameters(tls: .none)
++		params.includePeerToPeer = true
++		tcpListener=try! NWListener(using: params)
+ 		super.init()
+ 	}
+ 	
+@@ -251,6 +253,7 @@ public class NearbyConnectionManager : NSObject, NetServiceDelegate, InboundNear
+ 		
+ 		let port:Int32=Int32(tcpListener.port!.rawValue)
+ 		mdnsService=NetService(domain: "", type: "_FC9F5ED42C8A._tcp.", name: name, port: port)
++		mdnsService?.includesPeerToPeer=true
+ 		mdnsService?.delegate=self
+ 		mdnsService?.setTXTRecord(NetService.data(fromTXTRecord: [
+ 			"n": endpointInfo.serialize().urlSafeBase64EncodedString().data(using: .utf8)!
+@@ -278,7 +281,9 @@ public class NearbyConnectionManager : NSObject, NetServiceDelegate, InboundNear
+ 		if discoveryRefCount==0{
+ 			foundServices.removeAll()
+ 			if browser==nil{
+-				browser=NWBrowser(for: .bonjourWithTXTRecord(type: "_FC9F5ED42C8A._tcp.", domain: nil), using: .tcp)
++				let params = NWParameters.tcp
++				params.includePeerToPeer = true
++				browser=NWBrowser(for: .bonjourWithTXTRecord(type: "_FC9F5ED42C8A._tcp.", domain: nil), using: params)
+ 				browser?.browseResultsChangedHandler={newResults, changes in
+ 					for change in changes{
+ 						switch change{


### PR DESCRIPTION
hey, noticed that the app stopped being discoverable on the newer macos updates (sequoia/tahoe).

apple got pretty strict with local network privacy recently, so mDNS packets just get dropped silently if the p2p flags aren't set. i went ahead and added the missing `includePeerToPeer` flags to the network listeners and also added the local network usage description to the plist so it actually prompts the user for permission now.

tested it on my machine and it works perfectly again. let me know if you need any changes!