### PR TITLE
Fix silent failure receiving files: read large frames in bounded chunks

### DIFF
--- a/NearbyShare/NearbyConnection.swift
+++ b/NearbyShare/NearbyConnection.swift
@@ -126,14 +126,14 @@ class NearbyConnection{
 	}
 	
 	private func receiveFrameAsync(length:UInt32){
-		receiveFrameChunkAsync(remaining: Int(length), accumulated: Data(capacity: Int(length)))
+		receiveFrameChunkAsync(remaining: Int(length), accumulated: NSMutableData(capacity: Int(length)) ?? NSMutableData())
 	}
 
 	// File payloads arrive in 512 KB frames, and asking for one of those in a single receive
 	// hands back damaged bytes, so reassemble the frame from bounded reads instead.
-	private func receiveFrameChunkAsync(remaining:Int, accumulated:Data){
+	private func receiveFrameChunkAsync(remaining:Int, accumulated:NSMutableData){
 		if remaining<=0{
-			processReceivedFrame(frameData: accumulated)
+			processReceivedFrame(frameData: accumulated as Data)
 			receiveFrameAsync()
 			return
 		}
@@ -149,9 +149,8 @@ class NearbyConnection{
 				self.protocolError()
 				return
 			}
-			var next=accumulated
-			next.append(content)
-			self.receiveFrameChunkAsync(remaining: remaining-content.count, accumulated: next)
+			accumulated.append(content)
+			self.receiveFrameChunkAsync(remaining: remaining-content.count, accumulated: accumulated)
 		}
 	}
 	

--- a/NearbyShare/NearbyConnection.swift
+++ b/NearbyShare/NearbyConnection.swift
@@ -16,6 +16,7 @@ import BigInt
 
 class NearbyConnection{
 	internal static let SANE_FRAME_LENGTH=5*1024*1024
+	private static let MAX_RECEIVE_LENGTH=16*1024
 	private static let dispatchQueue=DispatchQueue(label: "me.grishka.NearDrop.queue", qos: .utility) // FIFO (non-concurrent) queue to avoid those exciting concurrency bugs
 	
 	internal let connection:NWConnection
@@ -125,7 +126,18 @@ class NearbyConnection{
 	}
 	
 	private func receiveFrameAsync(length:UInt32){
-		connection.receive(minimumIncompleteLength: Int(length), maximumLength: Int(length)) { content, contentContext, isComplete, error in
+		receiveFrameChunkAsync(remaining: Int(length), accumulated: Data(capacity: Int(length)))
+	}
+
+	// File payloads arrive in 512 KB frames, and asking for one of those in a single receive
+	// hands back damaged bytes, so reassemble the frame from bounded reads instead.
+	private func receiveFrameChunkAsync(remaining:Int, accumulated:Data){
+		if remaining<=0{
+			processReceivedFrame(frameData: accumulated)
+			receiveFrameAsync()
+			return
+		}
+		connection.receive(minimumIncompleteLength: 1, maximumLength: min(remaining, NearbyConnection.MAX_RECEIVE_LENGTH)) { content, contentContext, isComplete, error in
 			if self.connectionClosed{
 				return
 			}
@@ -133,12 +145,13 @@ class NearbyConnection{
 				self.handleConnectionClosure()
 				return
 			}
-			guard let content=content else {
+			guard let content=content, !content.isEmpty else {
 				self.protocolError()
 				return
 			}
-			self.processReceivedFrame(frameData: content)
-			self.receiveFrameAsync()
+			var next=accumulated
+			next.append(content)
+			self.receiveFrameChunkAsync(remaining: remaining-content.count, accumulated: next)
 		}
 	}
 	


### PR DESCRIPTION
## Problem

Receiving any file larger than ~512 KB fails silently. The consent prompt appears, the destination file is created in `~/Downloads`, and then nothing is written. The sender's progress stays at 0% and it closes the connection after ~35 s. No error notification, no crash. This reproduces every time on my setup — macOS 26.6.2 (Apple Silicon), receiving from a Nothing Phone (1).

## Cause

`receiveFrameAsync(length:)` asks `NWConnection` for the whole frame in one call:

```swift
connection.receive(minimumIncompleteLength: Int(length), maximumLength: Int(length))
```

File payloads arrive as ~512 KB frames. For a 524,456-byte frame this returns the right number of bytes, but they are not the bytes that were sent, so `Securemessage_SecureMessage(serializedData:)` throws `malformedProtobuf` and the receive loop stops. Handshake frames (100–300 bytes) are unaffected, which is why the connection gets all the way to the transfer before dying.

The damage is not deterministic. Across runs the same frame failed as `malformedProtobuf`, and as `requiredFieldMissing("d2dMessage.message|sequenceNumber")` after the body decrypted. The frame's own length arithmetic was always self-consistent (`0a` + varint(524418) + header 28 + body 524384 + 34 = 524456), but the trailing 34 bytes were never the `12 20` + 32-byte signature field, and their contents differed every run.

Ruled out along the way: SwiftProtobuf 1.21.0 (a synthetic buffer of the same shape parses fine), the `BANDWIDTH_UPGRADE_RETRY` frame, and the decrypt path.

## Fix

Reassemble the frame from bounded reads. Nothing else changes; small frames still complete in a single read. Chunks accumulate in an `NSMutableData`, matching how `payloadBuffers` already collects payloads in this file. Bounded reads seem like the more robust shape here regardless of what makes the single large receive misbehave.

The 16 KB chunk size is a conservative pick, not a measured one. Larger chunks may work equally well and would mean fewer round trips through the receive callback — happy to change it.

## Testing

Receiving from a Nothing Phone (1), where every one of these produced a 0-byte file before the change:

- a single 4,016,108-byte JPEG — arrives complete and byte-exact, opens normally
- three PNGs (1.8–2.1 MB) sent together — all three arrive complete

The reassembled frames pass the HMAC check, so verification is unaffected.
